### PR TITLE
execute function at end of exp, events for begin and end

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 results/
 fairreckitlib/run_dev_helper.py
-run_dev_helper.py
+src/run_dev_helper.py
 
 **/*.egg-info/**
 .vscode/

--- a/src/fairreckitlib/events/experiment_event.py
+++ b/src/fairreckitlib/events/experiment_event.py
@@ -1,0 +1,59 @@
+"""
+This program has been developed by students from the bachelor Computer Science at
+Utrecht University within the Software Project course.
+© Copyright Utrecht University (Department of Information and Computing Sciences)
+"""
+
+ON_BEGIN_EXP = 'on_begin_experiment'
+ON_END_EXP = 'on_end_experiment'
+
+
+def get_experiment_events():
+    """Gets all experiment pipeline events.
+
+    Returns:
+        (array like) list of pairs in the format (event_id, func_on_event)
+    """
+    return [
+        (ON_BEGIN_EXP, on_begin_experiment),
+        (ON_END_EXP, on_end_experiment)
+    ]
+
+
+def on_begin_experiment(event_listener, **kwargs):
+    """Callback function when a model computation started.
+
+    Args:
+        event_listener(object): the listener that is registered
+            in the event dispatcher with this callback.
+
+    Keyword Args:
+        experiment_name(str): name of the experiment (run).
+    """
+    if event_listener.verbose:
+        if 'num_runs' in kwargs:
+            print('Starting', kwargs['num_runs'], 'experiment(s) with name', kwargs['experiment_name'])
+        else:
+            print('Starting experiment', kwargs['experiment_name'])
+
+
+def on_end_experiment(event_listener, **kwargs):
+    """Callback function when a model computation finished.
+
+    Args:
+        event_listener(object): the listener that is registered
+            in the event dispatcher with this callback.
+
+    Keyword Args:
+        experiment_name(str): name of the experiment (run).
+        elapsed_time(float): the time that has passed since the model
+            computation started, expressed in seconds.
+    """
+    if event_listener.verbose:
+        if 'num_runs' in kwargs:
+            print('Finished', kwargs['num_runs'], 'experiment(s) with name', kwargs['experiment_name'])
+            kwargs['on_end_experiment']()
+        else:
+            elapsed_time = kwargs['elapsed_time']
+            print('Finished experiment', kwargs['experiment_name'], f'in {elapsed_time:1.4f}s')
+

--- a/src/fairreckitlib/experiment/parsing/datasets.py
+++ b/src/fairreckitlib/experiment/parsing/datasets.py
@@ -194,8 +194,8 @@ def parse_data_split_config(dataset_config, dataset_name, split_factory, event_d
             EXP_KEY_DATASET_SPLIT_TEST_RATIO,
             float,
             EXP_DEFAULT_SPLIT_TEST_RATIO,
-            0.01,
-            0.99
+            (0.01,
+            0.99)
         ),
         event_dispatcher
     )


### PR DESCRIPTION
- the recommender system takes a function as argument to execute at the end of a thread experiment (one or bulk experiment)
- begin and end messages are added

How I did it is kind of questionable, could either
1. add a static function variable to experiment_events
2. it might be better to make the adding of events accessible outside of recommender system? e.g. for the progress bar as well? 