### PR TITLE
Config parsing refactor

### DIFF
--- a/config_files/predictors_all.yml
+++ b/config_files/predictors_all.yml
@@ -1,5 +1,9 @@
 datasets:
 - name: ML-100K
+  rating_converter:
+    name: range
+  splitting:
+    name: random
 evaluation:
 - name: MAE
 - name: RMSE

--- a/config_files/recommenders_all.yml
+++ b/config_files/recommenders_all.yml
@@ -1,5 +1,9 @@
 datasets:
 - name: ML-100K
+  rating_converter:
+    name: range
+  splitting:
+    name: random
 evaluation:
 - name: NDCG@K
 - name: P@K

--- a/src/fairreckitlib/core/config_object.py
+++ b/src/fairreckitlib/core/config_object.py
@@ -1,0 +1,46 @@
+"""
+This program has been developed by students from the bachelor Computer Science at
+Utrecht University within the Software Project course.
+© Copyright Utrecht University (Department of Information and Computing Sciences)
+"""
+
+from dataclasses import dataclass
+from typing import Any, Dict, List
+
+from .config_constants import KEY_NAME, KEY_PARAMS
+
+
+@dataclass
+class ObjectConfig:
+    """Base Object Configuration."""
+
+    name: str
+    params: Dict[str, Any]
+
+    def to_yml_format(self) -> Dict[str, Any]:
+        """Format object configuration to a yml compatible dictionary.
+
+        Returns:
+            a dictionary containing the object configuration.
+        """
+        yml_format = { KEY_NAME: self.name }
+
+        # only include object params if it has entries
+        if len(self.params) > 0:
+            yml_format[KEY_PARAMS] = dict(self.params)
+
+        return yml_format
+
+
+def object_config_list_to_yml_format(object_configs: List[ObjectConfig]) -> List[Dict[str, Any]]:
+    """Format object configuration list to a yml compatible list.
+
+    Returns:
+        a list containing the object configuration's.
+    """
+    yml_format = []
+
+    for obj in object_configs:
+        yml_format.append(obj.to_yml_format())
+
+    return yml_format

--- a/src/fairreckitlib/data/data_factory.py
+++ b/src/fairreckitlib/data/data_factory.py
@@ -5,9 +5,10 @@ Utrecht University within the Software Project course.
 """
 
 from ..core.factories import GroupFactory
-from .pipeline.data_config import KEY_DATASETS
 from .ratings.rating_converter_factory import create_rating_converter_factory
 from .split.split_factory import create_split_factory
+
+KEY_DATASETS = 'datasets'
 
 
 def create_data_factory() -> GroupFactory:

--- a/src/fairreckitlib/data/filter/filter_constants.py
+++ b/src/fairreckitlib/data/filter/filter_constants.py
@@ -4,11 +4,4 @@ Utrecht University within the Software Project course.
 © Copyright Utrecht University (Department of Information and Computing Sciences)
 """
 
-from dataclasses import dataclass
-
-from ...core.config_object import ObjectConfig
-
-
-@dataclass
-class ConvertConfig(ObjectConfig):
-    """Dataset rating conversion Configuration."""
+KEY_DATA_FILTERS = 'filters'

--- a/src/fairreckitlib/data/pipeline/data_config.py
+++ b/src/fairreckitlib/data/pipeline/data_config.py
@@ -5,13 +5,14 @@ Utrecht University within the Software Project course.
 """
 
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Dict, Optional
 
+from ...core.config_constants import KEY_NAME
+from ..filter.filter_constants import KEY_DATA_FILTERS
+from ..ratings.convert_constants import KEY_RATING_CONVERTER
 from ..ratings.convert_config import ConvertConfig
+from ..split.split_constants import KEY_SPLITTING
 from ..split.split_config import SplitConfig
-
-KEY_DATASETS = 'datasets'
-KEY_DATA_FILTERS = 'filters'
 
 
 @dataclass
@@ -22,3 +23,25 @@ class DatasetConfig:
     prefilters: []
     converter: Optional[ConvertConfig]
     splitting: SplitConfig
+
+    def to_yml_format(self) -> Dict[str, Any]:
+        """Format dataset configuration to a yml compatible dictionary.
+
+        Returns:
+            a dictionary containing the dataset configuration.
+        """
+        yml_format = {
+            KEY_NAME: self.name,
+            KEY_SPLITTING: self.splitting.to_yml_format()
+        }
+
+        # only include prefilters if it has entries
+        if len(self.prefilters) > 0:
+            # TODO convert filters to yml format
+            yml_format[KEY_DATA_FILTERS] = []
+
+        # only include rating modifier if it is present
+        if self.converter:
+            yml_format[KEY_RATING_CONVERTER] = self.converter.to_yml_format()
+
+        return yml_format

--- a/src/fairreckitlib/data/pipeline/data_event.py
+++ b/src/fairreckitlib/data/pipeline/data_event.py
@@ -100,7 +100,7 @@ def on_begin_modify_dataset(event_listener: Any, **kwargs) -> None:
             applied to the dataset.
     """
     if event_listener.verbose:
-        print('Converting dataset ratings:', kwargs['rating_modifier'])
+        print('Converting dataset ratings:', kwargs['rating_converter'])
 
 
 def on_begin_save_sets(event_listener: Any, **kwargs) -> None:

--- a/src/fairreckitlib/data/ratings/convert_config_parsing.py
+++ b/src/fairreckitlib/data/ratings/convert_config_parsing.py
@@ -1,0 +1,104 @@
+"""
+This program has been developed by students from the bachelor Computer Science at
+Utrecht University within the Software Project course.
+© Copyright Utrecht University (Department of Information and Computing Sciences)
+"""
+
+from typing import Any, Dict, Optional
+
+from ...core.config_constants import KEY_NAME, KEY_PARAMS
+from ...core.config_params import ConfigOptionParam
+from ...core.event_dispatcher import EventDispatcher
+from ...core.factories import Factory
+from ...core.parsing.parse_assert import assert_is_type, assert_is_key_in_dict
+from ...core.parsing.parse_event import ON_PARSE
+from ...core.parsing.parse_params import parse_config_param, parse_config_parameters
+from ..set.dataset import Dataset
+from .convert_config import ConvertConfig
+from .convert_constants import KEY_RATING_CONVERTER
+
+
+def parse_data_convert_config(
+        dataset_config: Dict[str, Any],
+        dataset: Dataset,
+        converter_factory: Factory,
+        event_dispatcher: EventDispatcher) -> Optional[ConvertConfig]:
+    """Parse a dataset rating converter configuration.
+
+    Args:
+        dataset_config: the dataset's total configuration.
+        dataset: the dataset related to the converter configuration.
+        converter_factory: the converter factory containing available converters.
+        event_dispatcher: to dispatch the parse event on failure.
+
+    Returns:
+        the parsed configuration or None on failure.
+    """
+    parsed_config = None
+
+    # dataset rating conversion is optional
+    if KEY_RATING_CONVERTER not in dataset_config:
+        event_dispatcher.dispatch(
+            ON_PARSE,
+            msg='PARSE WARNING: dataset ' + dataset.name + ' missing key \'' +
+                KEY_RATING_CONVERTER + '\'',
+            default=parsed_config
+        )
+        return parsed_config
+
+    convert_config = dataset_config[KEY_RATING_CONVERTER]
+
+    # assert convert_config is a dict
+    if not assert_is_type(
+        convert_config,
+        dict,
+        event_dispatcher,
+        'PARSE WARNING: dataset ' + dataset.name + ' invalid rating conversion value',
+        default=parsed_config
+    ): return parsed_config
+
+    # parse converter name
+    success, converter_name = parse_config_param(
+        convert_config,
+        dataset.name + ' ' + KEY_RATING_CONVERTER,
+        ConfigOptionParam(
+            KEY_NAME,
+            str,
+            'None',
+            converter_factory.get_available_names()
+        ),
+        event_dispatcher
+    )
+    if not success:
+        return parsed_config
+
+    convert_params = converter_factory.create_params(converter_name)
+    upper_bound = convert_params.get_param('upper_bound')
+    if upper_bound is not None:
+        # update upper_bound param's default value to match the dataset's max rating
+        upper_bound.default_value = dataset.get_matrix_info('rating_max')
+
+    parsed_config = ConvertConfig(
+        converter_name,
+        convert_params.get_defaults()
+    )
+
+    # assert KEY_PARAMS is present
+    # skip when the splitter has no parameters at all
+    if convert_params.get_num_params() > 0 and assert_is_key_in_dict(
+        KEY_PARAMS,
+        convert_config,
+        event_dispatcher,
+        'PARSE WARNING: dataset ' + dataset.name + ' ' + KEY_RATING_CONVERTER + ' missing key \'' +
+        KEY_PARAMS + '\'',
+        default=parsed_config.params
+    ):
+        # parse the splitter parameters
+        parsed_config.params = parse_config_parameters(
+            convert_config[KEY_PARAMS],
+            dataset.name,
+            convert_params,
+            event_dispatcher
+        )
+
+    return parsed_config

--- a/src/fairreckitlib/data/ratings/range_converter.py
+++ b/src/fairreckitlib/data/ratings/range_converter.py
@@ -68,5 +68,5 @@ def create_range_converter_params() -> ConfigParameters:
         the configuration parameters of the converter.
     """
     params = ConfigParameters()
-    params.add_value('upper_bound', float, 1.0, (1.0, 1000.0))
+    params.add_value('upper_bound', float, 1.0, (1.0, 1000000.0))
     return params

--- a/src/fairreckitlib/data/split/split_config.py
+++ b/src/fairreckitlib/data/split/split_config.py
@@ -7,35 +7,22 @@ Utrecht University within the Software Project course.
 from dataclasses import dataclass
 from typing import Any, Dict
 
-from ...core.config_constants import KEY_NAME, KEY_PARAMS
+from ...core.config_object import ObjectConfig
 from .split_constants import KEY_SPLIT_TEST_RATIO
 
 
 @dataclass
-class SplitConfig:
+class SplitConfig(ObjectConfig):
     """Dataset Splitting Configuration."""
 
-    name: str
     test_ratio: float
-    params: Dict[str, Any]
 
+    def to_yml_format(self) -> Dict[str, Any]:
+        """Format splitting configuration to a yml compatible dictionary.
 
-def split_config_to_dict(split_config: SplitConfig) -> Dict[str, Any]:
-    """Convert a splitting configuration to a dictionary.
-
-    Args:
-        split_config: the configuration to convert to dictionary.
-
-    Returns:
-        a dictionary containing the splitting configuration.
-    """
-    splitting = {
-        KEY_NAME: split_config.name,
-        KEY_SPLIT_TEST_RATIO: split_config.test_ratio
-    }
-
-    # only include splitting params if it has entries
-    if len(split_config.params) > 0:
-        splitting[KEY_PARAMS] = split_config.params
-
-    return splitting
+        Returns:
+            a dictionary containing the splitting configuration.
+        """
+        yml_format = ObjectConfig.to_yml_format(self)
+        yml_format[KEY_SPLIT_TEST_RATIO] = self.test_ratio
+        return yml_format

--- a/src/fairreckitlib/data/split/split_config_parsing.py
+++ b/src/fairreckitlib/data/split/split_config_parsing.py
@@ -13,6 +13,7 @@ from ...core.factories import Factory
 from ...core.parsing.parse_assert import assert_is_type, assert_is_key_in_dict
 from ...core.parsing.parse_event import ON_PARSE
 from ...core.parsing.parse_params import parse_config_param, parse_config_parameters
+from ..set.dataset import Dataset
 from .split_config import SplitConfig
 from .split_constants import KEY_SPLITTING, KEY_SPLIT_TEST_RATIO
 from .split_constants import DEFAULT_SPLIT_TEST_RATIO, DEFAULT_SPLIT_NAME
@@ -20,14 +21,14 @@ from .split_constants import DEFAULT_SPLIT_TEST_RATIO, DEFAULT_SPLIT_NAME
 
 def parse_data_split_config(
         dataset_config: Dict[str, Any],
-        dataset_name: str,
+        dataset: Dataset,
         split_factory: Factory,
         event_dispatcher: EventDispatcher) -> SplitConfig:
     """Parse a dataset splitting configuration.
 
     Args:
         dataset_config: the dataset's total configuration.
-        dataset_name: the dataset name related to the splitting configuration.
+        dataset: the dataset related to the splitting configuration.
         split_factory: the split factory containing available splitters.
         event_dispatcher: to dispatch the parse event on failure.
 
@@ -36,15 +37,15 @@ def parse_data_split_config(
     """
     parsed_config = SplitConfig(
         DEFAULT_SPLIT_NAME,
-        DEFAULT_SPLIT_TEST_RATIO,
-        split_factory.create_params(DEFAULT_SPLIT_NAME).get_defaults()
+        split_factory.create_params(DEFAULT_SPLIT_NAME).get_defaults(),
+        DEFAULT_SPLIT_TEST_RATIO
     )
 
     # dataset splitting is optional
     if KEY_SPLITTING not in dataset_config:
         event_dispatcher.dispatch(
             ON_PARSE,
-            msg='PARSE WARNING: dataset ' + dataset_name + ' missing key \'' +
+            msg='PARSE WARNING: dataset ' + dataset.name + ' missing key \'' +
                 KEY_SPLITTING + '\'',
             default=parsed_config
         )
@@ -57,14 +58,14 @@ def parse_data_split_config(
         split_config,
         dict,
         event_dispatcher,
-        'PARSE WARNING: dataset ' + dataset_name + ' invalid splitting value',
+        'PARSE WARNING: dataset ' + dataset.name + ' invalid splitting value',
         default=parsed_config
     ): return parsed_config
 
     # parse splitting test ratio
     success, test_ratio = parse_config_param(
         split_config,
-        dataset_name + ' ' + KEY_SPLITTING,
+        dataset.name + ' ' + KEY_SPLITTING,
         ConfigValueParam(
             KEY_SPLIT_TEST_RATIO,
             float,
@@ -76,10 +77,10 @@ def parse_data_split_config(
     if success:
         parsed_config.test_ratio = test_ratio
 
-    # parse splitting type
-    success, split_type = parse_config_param(
+    # parse splitting name
+    success, split_name = parse_config_param(
         split_config,
-        dataset_name + ' ' + KEY_SPLITTING,
+        dataset.name + ' ' + KEY_SPLITTING,
         ConfigOptionParam(
             KEY_NAME,
             str,
@@ -89,9 +90,9 @@ def parse_data_split_config(
         event_dispatcher
     )
     if success:
-        parsed_config.name = split_type
+        parsed_config.name = split_name
 
-    split_params = split_factory.create_params(split_type)
+    split_params = split_factory.create_params(split_name)
     parsed_config.params = split_params.get_defaults()
 
     # assert KEY_PARAMS is present
@@ -100,14 +101,14 @@ def parse_data_split_config(
         KEY_PARAMS,
         split_config,
         event_dispatcher,
-        'PARSE WARNING: dataset ' + dataset_name + ' ' + KEY_SPLITTING + ' missing key \'' +
+        'PARSE WARNING: dataset ' + dataset.name + ' ' + KEY_SPLITTING + ' missing key \'' +
         KEY_PARAMS + '\'',
         default=parsed_config.params
     ):
         # parse the splitter parameters
         parsed_config.params = parse_config_parameters(
             split_config[KEY_PARAMS],
-            dataset_name,
+            dataset.name,
             split_params,
             event_dispatcher
         )

--- a/src/fairreckitlib/evaluation/evaluation_factory.py
+++ b/src/fairreckitlib/evaluation/evaluation_factory.py
@@ -6,15 +6,21 @@ Utrecht University within the Software Project course.
 
 from ..core.config_constants import TYPE_PREDICTION, TYPE_RECOMMENDATION
 from ..core.factories import GroupFactory
-from .pipeline.evaluation_config import KEY_EVALUATION
 from .metrics.metric_factory import create_accuracy_metric_factory
 from .metrics.metric_factory import create_coverage_metric_factory
 from .metrics.metric_factory import create_diversity_metric_factory
 from .metrics.metric_factory import create_novelty_metric_factory
 from .metrics.metric_factory import create_rating_metric_factory
 
+KEY_EVALUATION = 'evaluation'
 
-def create_evaluation_factory():
+
+def create_evaluation_factory() -> GroupFactory:
+    """Create a factory with all predictor and recommender metric category factories.
+
+    Returns:
+        the group factory with available predictor and recommender factories.
+    """
     shared_categories = [
         create_coverage_metric_factory,
         create_diversity_metric_factory,

--- a/src/fairreckitlib/evaluation/pipeline/evaluation_config.py
+++ b/src/fairreckitlib/evaluation/pipeline/evaluation_config.py
@@ -5,15 +5,29 @@ Utrecht University within the Software Project course.
 """
 
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Dict
 
-KEY_EVALUATION = 'evaluation'
+from ...core.config_object import ObjectConfig
+from ...data.filter.filter_constants import KEY_DATA_FILTERS
 
 
 @dataclass
-class MetricConfig:
+class MetricConfig(ObjectConfig):
     """Metric Configuration."""
 
-    name: str
-    params: {str: Any}
     prefilters: []
+
+    def to_yml_format(self) -> Dict[str, Any]:
+        """Format metric configuration to a yml compatible dictionary.
+
+        Returns:
+            a dictionary containing the metric configuration.
+        """
+        yml_format = ObjectConfig.to_yml_format(self)
+
+        # only include prefilters if it has entries
+        if len(self.prefilters) > 0:
+            # TODO convert filters to yml format
+            yml_format[KEY_DATA_FILTERS] = self.prefilters
+
+        return yml_format

--- a/src/fairreckitlib/evaluation/pipeline/evaluation_config_parsing.py
+++ b/src/fairreckitlib/evaluation/pipeline/evaluation_config_parsing.py
@@ -4,25 +4,33 @@ Utrecht University within the Software Project course.
 © Copyright Utrecht University (Department of Information and Computing Sciences)
 """
 
+from typing import Any, Dict, List, Optional, Tuple
+
 from ...core.config_constants import KEY_NAME, KEY_PARAMS, KEY_TOP_K
+from ...core.event_dispatcher import EventDispatcher
+from ...core.factories import GroupFactory
 from ...core.parsing.parse_assert import assert_is_type, assert_is_container_not_empty
 from ...core.parsing.parse_assert import assert_is_key_in_dict, assert_is_one_of_list
 from ...core.parsing.parse_event import ON_PARSE
 from ...core.parsing.parse_params import parse_config_parameters
+from ..evaluation_factory import KEY_EVALUATION
 from ..metrics.metric_factory import KEY_METRIC_PARAM_K, resolve_metric_factory
-from .evaluation_config import MetricConfig, KEY_EVALUATION
+from .evaluation_config import MetricConfig
 
 
-def parse_evaluation_config(experiment_config, metric_category_factory, event_dispatcher):
-    """Parses all metric configurations.
+def parse_evaluation_config(
+        experiment_config: Dict[str, Any],
+        metric_category_factory: GroupFactory,
+        event_dispatcher: EventDispatcher) -> List[MetricConfig]:
+    """Parse all metric configurations.
 
     Args:
-        experiment_config(dict): the experiment's total configuration.
-        metric_category_factory(GroupFactory): the metric factory containing grouped available metrics.
-        event_dispatcher(EventDispatcher): to dispatch the parse event on failure.
+        experiment_config: the experiment's total configuration.
+        metric_category_factory: the metric factory containing grouped available metrics.
+        event_dispatcher: to dispatch the parse event on failure.
 
     Returns:
-        parsed_config(array like): list of parsed MetricConfig's.
+        a list of parsed MetricConfig's which is possibly empty.
     """
     parsed_config = []
 
@@ -70,18 +78,22 @@ def parse_evaluation_config(experiment_config, metric_category_factory, event_di
 
     return parsed_config
 
-def parse_metric_config(metric_config, metric_category_factory, top_k, event_dispatcher):
-    """Parses a metric configuration.
+
+def parse_metric_config(
+        metric_config: Dict[str, Any],
+        metric_category_factory: GroupFactory,
+        top_k: int,
+        event_dispatcher: EventDispatcher) -> Tuple[Optional[MetricConfig], Optional[str]]:
+    """Parse a metric configuration.
 
     Args:
-        metric_config(dict): the metrics configuration.
-        metric_category_factory(GroupFactory): the metric factory containing grouped available metrics.
-        top_k(int): the top_K value for recommendation and None for prediction.
-        event_dispatcher(EventDispatcher): to dispatch the parse event on failure.
+        metric_config: the metrics configuration.
+        metric_category_factory: the metric factory containing grouped available metrics.
+        top_k: the top_K value for recommendation and None for prediction.
+        event_dispatcher: to dispatch the parse event on failure.
 
     Returns:
-        parsed_config(MetricConfig): the parsed configuration or None on failure.
-        metric_name(str): the name of the parsed metric or None on failure.
+        the parsed configuration and the metric name or None on failure.
     """
     # assert dataset_config is a dict
     if not assert_is_type(

--- a/src/fairreckitlib/experiment/experiment_config.py
+++ b/src/fairreckitlib/experiment/experiment_config.py
@@ -5,16 +5,17 @@ Utrecht University within the Software Project course.
 """
 
 from dataclasses import dataclass
+from typing import Any, Dict, List
 
-from ..core.config_constants import KEY_NAME, KEY_PARAMS, KEY_TYPE
+from ..core.config_constants import KEY_NAME, KEY_TYPE
 from ..core.config_constants import KEY_TOP_K, KEY_RATED_ITEMS_FILTER
-from ..data.pipeline.data_config import DatasetConfig, KEY_DATASETS, KEY_DATA_FILTERS
-from ..data.ratings.rating_converter_factory import KEY_RATING_CONVERTER
-from ..data.split.split_constants import KEY_SPLITTING
-from ..data.split.split_config import split_config_to_dict
-from ..data.utility import save_yml
-from ..evaluation.pipeline.evaluation_config import MetricConfig, KEY_EVALUATION
-from ..model.pipeline.model_config import ModelConfig, KEY_MODELS
+from ..core.config_object import object_config_list_to_yml_format
+from ..data.data_factory import KEY_DATASETS
+from ..data.pipeline.data_config import DatasetConfig
+from ..evaluation.evaluation_factory import KEY_EVALUATION
+from ..evaluation.pipeline.evaluation_config import MetricConfig
+from ..model.model_factory import KEY_MODELS
+from ..model.pipeline.model_config import ModelConfig, api_models_to_yml_format
 
 
 @dataclass
@@ -22,10 +23,29 @@ class ExperimentConfig:
     """Base Experiment Configuration."""
 
     datasets: [DatasetConfig]
-    models: {str: [ModelConfig]}
+    models: Dict[str, List[ModelConfig]]
     evaluation: [MetricConfig]
     name: str
     type: str
+
+    def to_yml_format(self) -> Dict[str, Any]:
+        """Format experiment configuration to a yml compatible dictionary.
+
+        Returns:
+            a dictionary containing the experiment configuration.
+        """
+        yml_format = {
+            KEY_NAME: self.name,
+            KEY_TYPE: self.type,
+            KEY_DATASETS: object_config_list_to_yml_format(self.datasets),
+            KEY_MODELS: api_models_to_yml_format(self.models)
+        }
+
+        # only include evaluation if it is present
+        if len(self.evaluation) > 0:
+            yml_format[KEY_EVALUATION] = object_config_list_to_yml_format(self.evaluation)
+
+        return yml_format
 
 
 @dataclass
@@ -40,90 +60,13 @@ class RecommenderExperimentConfig(ExperimentConfig):
     top_k: int
     rated_items_filter: bool
 
+    def to_yml_format(self) -> Dict[str, Any]:
+        """Format recommender experiment configuration to a yml compatible dictionary.
 
-def save_config_to_yml(file_path, experiment_config):
-    """Saves an experiment configuration to a yml file.
-
-    Args:
-        file_path(str): path to the yml file without extension.
-        experiment_config(ExperimentConfig): the configuration to save.
-    """
-    experiment_config = experiment_config_to_dict(experiment_config)
-    save_yml(file_path + '.yml', experiment_config)
-
-
-def experiment_config_to_dict(experiment_config: ExperimentConfig):
-    """Converts an experiment configuration to a dictionary.
-
-    Defines the layout of a configuration file for yml support.
-
-    Args:
-        experiment_config(ExperimentConfig): the configuration to convert to dictionary.
-
-    Returns:
-        (dict): containing the experiment configuration.
-    """
-    config = {
-        KEY_NAME: experiment_config.name,
-        KEY_TYPE: experiment_config.type,
-        KEY_DATASETS: [],
-        KEY_MODELS: {}
-    }
-
-    if isinstance(experiment_config, RecommenderExperimentConfig):
-        config[KEY_TOP_K] = experiment_config.top_k
-        config[KEY_RATED_ITEMS_FILTER] = experiment_config.rated_items_filter
-
-    for _, dataset_config in enumerate(experiment_config.datasets):
-        dataset = {
-            KEY_NAME: dataset_config.name,
-            KEY_SPLITTING: split_config_to_dict(dataset_config.splitting)
-        }
-
-        # only include prefilters if it has entries
-        if len(dataset_config.prefilters) > 0:
-            # TODO
-            dataset[KEY_DATA_FILTERS] = []
-
-        # only include rating modifier if it is present
-        if dataset_config.converter:
-            # TODO
-            dataset[KEY_RATING_CONVERTER] = dataset_config.converter
-
-        config[KEY_DATASETS].append(dataset)
-
-    for api_name, models in experiment_config.models.items():
-        config[KEY_MODELS][api_name] = []
-
-        for _, model_config in enumerate(models):
-            param_config = {}
-            for param_name, param_value in model_config.params.items():
-                param_config[param_name] = param_value
-
-            model = {KEY_NAME: model_config.name}
-
-            # only include model params if it has entries
-            if len(param_config) > 0:
-                model[KEY_PARAMS] = param_config
-
-            config[KEY_MODELS][api_name].append(model)
-
-    # only include evaluation if it is present
-    if len(experiment_config.evaluation) > 0:
-        config[KEY_EVALUATION] = []
-
-        for _, metric_config in enumerate(experiment_config.evaluation):
-            metric = {KEY_NAME: metric_config.name}
-
-            # only include metric params if it has entries
-            if len(metric_config.params) > 0:
-                metric[KEY_PARAMS] = metric_config.params
-
-            # only include prefilters if it has entries
-            if len(metric_config.prefilters) > 0:
-                # TODO
-                metric[KEY_DATA_FILTERS] = metric_config.prefilters
-
-            config[KEY_EVALUATION].append(metric)
-
-    return config
+        Returns:
+            a dictionary containing the experiment configuration.
+        """
+        yml_format = ExperimentConfig.to_yml_format(self)
+        yml_format[KEY_TOP_K] = self.top_k
+        yml_format[KEY_RATED_ITEMS_FILTER] = self.rated_items_filter
+        return yml_format

--- a/src/fairreckitlib/experiment/experiment_config_parsing.py
+++ b/src/fairreckitlib/experiment/experiment_config_parsing.py
@@ -4,17 +4,21 @@ Utrecht University within the Software Project course.
 © Copyright Utrecht University (Department of Information and Computing Sciences)
 """
 
+from typing import Any, Dict, Optional, Union
+
 from ..core.config_constants import KEY_TYPE, TYPE_PREDICTION, TYPE_RECOMMENDATION, VALID_TYPES
 from ..core.config_constants import KEY_NAME, KEY_TOP_K, DEFAULT_TOP_K
 from ..core.config_constants import KEY_RATED_ITEMS_FILTER, DEFAULT_RATED_ITEMS_FILTER
 from ..core.config_params import ConfigOptionParam, ConfigValueParam
 from ..core.event_dispatcher import EventDispatcher
-from ..core.parsing.parse_assert import assert_is_container_not_empty, assert_is_type
+from ..core.factories import GroupFactory
+from ..core.parsing.parse_assert import assert_is_type
 from ..core.parsing.parse_assert import assert_is_key_in_dict, assert_is_one_of_list
 from ..core.parsing.parse_event import ON_PARSE, on_parse
 from ..core.parsing.parse_params import parse_config_param
-from ..data.pipeline.data_config import KEY_DATASETS
+from ..data.data_factory import KEY_DATASETS
 from ..data.pipeline.data_config_parsing import parse_data_config
+from ..data.set.dataset_registry import DataRegistry
 from ..data.utility import load_yml
 from ..evaluation.evaluation_factory import KEY_EVALUATION
 from ..evaluation.pipeline.evaluation_config_parsing import parse_evaluation_config
@@ -24,274 +28,186 @@ from .experiment_config import PredictorExperimentConfig, RecommenderExperimentC
 
 
 class Parser:
-    def __init__(self, verbose):
+    """Experiment Configuration Parser.
+
+    Public methods:
+
+    parse_experiment_config
+    parse_experiment_config_from_yml
+    """
+
+    def __init__(self, verbose: bool):
+        """Construct the Parser.
+
+        Args:
+            verbose:
+        """
         self.verbose = verbose
         self.event_dispatcher = EventDispatcher()
         self.event_dispatcher.add_listener(ON_PARSE, self, (on_parse, None))
 
-    def parse_experiment_config(self, experiment_config, data_registry, experiment_factory):
-        """Parses an experiment configuration.
+    def parse_experiment_config(
+            self,
+            experiment_config: Dict[str, Any],
+            data_registry: DataRegistry,
+            experiment_factory: GroupFactory
+        ) -> Optional[Union[PredictorExperimentConfig, RecommenderExperimentConfig]]:
+        """Parse an experiment configuration.
 
         Args:
-            experiment_config(dict): the experiment's total configuration.
-            data_registry(DataRegistry): the data registry containing the available datasets.
-            experiment_factory(GroupFactory): the factory containing all three pipeline factories.
+            experiment_config: the experiment's total configuration.
+            data_registry: the data registry containing the available datasets.
+            experiment_factory: the factory containing all three pipeline factories.
 
         Returns:
-            parsed_config(ExperimentConfig): the parsed configuration or None on failure.
+            the parsed configuration or None on failure.
         """
+        # assert experiment_config is a dict
+        if not assert_is_type(
+            experiment_config,
+            dict,
+            self.event_dispatcher,
+            'PARSE ERROR: invalid experiment config type'
+        ): return None
+
+        # attempt to parse experiment name
+        experiment_name = self.parse_experiment_name(experiment_config)
+        if experiment_name is None:
+            return None
+
+        # attempt to parse experiment type
         experiment_type = self.parse_experiment_type(experiment_config)
+        if experiment_type is None:
+            return None
+
+        # attempt to parse experiment datasets
+        experiment_datasets = parse_data_config(
+            experiment_config,
+            data_registry,
+            experiment_factory.get_factory(KEY_DATASETS),
+            self.event_dispatcher
+        )
+        # experiment requires datasets
+        if experiment_datasets is None:
+            return None
+
+        # attempt to parse experiment models
+        experiment_models = parse_models_config(
+            experiment_config,
+            experiment_factory.get_factory(KEY_MODELS).get_factory(experiment_type),
+            self.event_dispatcher
+        )
+        # experiment requires models
+        if experiment_models is None:
+            return None
+
+        # attempt to parse experiment evaluation (optional)
+        experiment_evaluation = parse_evaluation_config(
+            experiment_config,
+            experiment_factory.get_factory(KEY_EVALUATION).get_factory(experiment_type),
+            self.event_dispatcher
+        )
+
+        parsed_config = None
 
         if experiment_type == TYPE_PREDICTION:
-            return self.parse_prediction_experiment_config(
-                experiment_config,
-                data_registry,
-                experiment_factory
+            parsed_config = PredictorExperimentConfig(
+                experiment_datasets,
+                experiment_models,
+                experiment_evaluation,
+                experiment_name,
+                experiment_type
             )
-        if experiment_type == TYPE_RECOMMENDATION:
-            return self.parse_recommender_experiment_config(
+        elif experiment_type == TYPE_RECOMMENDATION:
+            _, experiment_top_k = parse_config_param(
                 experiment_config,
-                data_registry,
-                experiment_factory
+                'recommender experiment',
+                ConfigValueParam(
+                    KEY_TOP_K,
+                    int,
+                    DEFAULT_TOP_K,
+                    (1, 100)
+                ),
+                self.event_dispatcher
             )
 
-        return None
+            _, experiment_rated_items_filter = parse_config_param(
+                experiment_config,
+                'recommender experiment',
+                ConfigOptionParam(
+                    KEY_RATED_ITEMS_FILTER,
+                    bool,
+                    DEFAULT_RATED_ITEMS_FILTER,
+                    [True, False]
+                ),
+                self.event_dispatcher
+            )
 
-    def parse_experiment_config_from_yml(self, file_path, data_registry, experiment_factory):
-        """Parses an experiment configuration from a yml file.
+            parsed_config = RecommenderExperimentConfig(
+                experiment_datasets,
+                experiment_models,
+                experiment_evaluation,
+                experiment_name,
+                experiment_type,
+                experiment_top_k,
+                experiment_rated_items_filter
+            )
+
+        return parsed_config
+
+    def parse_experiment_config_from_yml(
+            self,
+            file_path: str,
+            data_registry: DataRegistry,
+            experiment_factory: GroupFactory
+        ) -> Optional[Union[PredictorExperimentConfig, RecommenderExperimentConfig]]:
+        """Parse an experiment configuration from a yml file.
 
         Args:
-            file_path(str): path to the yml file without extension.
-            data_registry(DataRegistry): the data registry containing the available datasets.
-            experiment_factory(GroupFactory): the factory containing all three pipeline factories.
+            file_path: path to the yml file without extension.
+            data_registry: the data registry containing the available datasets.
+            experiment_factory: the factory containing all three pipeline factories.
 
         Returns:
-            parsed_config(ExperimentConfig): the parsed configuration or None on failure.
+            the parsed configuration or None on failure.
         """
         experiment_config = load_yml(file_path + '.yml')
 
         return self.parse_experiment_config(experiment_config, data_registry, experiment_factory)
 
-    def parse_prediction_experiment_config(self, experiment_config, data_registry, experiment_factory):
-        """Parses a prediction experiment configuration.
-
-        Args:
-            experiment_config(dict): the experiment's total configuration.
-            data_registry(DataRegistry): the data registry containing the available datasets.
-            experiment_factory(GroupFactory): the factory containing all three pipeline factories.
-
-        Returns:
-            parsed_config(PredictorExperimentConfig): the parsed configuration or None on failure.
-        """
-        if not self.parse_experiment_name(experiment_config):
-            return None
-
-        experiment_name = experiment_config[KEY_NAME]
-        experiment_type = experiment_config[KEY_TYPE]
-
-        experiment_datasets = self.parse_experiment_datasets(
-            experiment_config,
-            data_registry,
-            experiment_factory.get_factory(KEY_DATASETS)
-        )
-        if experiment_datasets is None:
-            return None
-
-        experiment_models = self.parse_experiment_models(
-            experiment_config,
-            experiment_factory.get_factory(KEY_MODELS).get_factory(TYPE_PREDICTION)
-        )
-        if experiment_models is None:
-            return None
-
-        experiment_evaluation = self.parse_experiment_evaluation(
-            experiment_config,
-            experiment_factory.get_factory(KEY_EVALUATION).get_factory(TYPE_PREDICTION)
-        )
-
-        parsed_config = PredictorExperimentConfig(
-            experiment_datasets,
-            experiment_models,
-            experiment_evaluation,
-            experiment_name,
-            experiment_type
-        )
-
-        return parsed_config
-
-    def parse_recommender_experiment_config(self, experiment_config, data_registry, experiment_factory):
-        """Parses a recommender experiment configuration.
-
-        Args:
-            experiment_config(dict): the experiment's total configuration.
-            data_registry(DataRegistry): the data registry containing the available datasets.
-            experiment_factory(GroupFactory): the factory containing all three pipeline factories.
-
-        Returns:
-            parsed_config(RecommenderExperimentConfig): the parsed configuration or None on failure.
-        """
-        if not self.parse_experiment_name(experiment_config):
-            return None
-
-        experiment_name = experiment_config[KEY_NAME]
-        experiment_type = experiment_config[KEY_TYPE]
-
-        experiment_datasets = self.parse_experiment_datasets(
-            experiment_config,
-            data_registry,
-            experiment_factory.get_factory(KEY_DATASETS)
-        )
-        if experiment_datasets is None:
-            return None
-
-        experiment_models = self.parse_experiment_models(
-            experiment_config,
-            experiment_factory.get_factory(KEY_MODELS).get_factory(TYPE_RECOMMENDATION)
-        )
-        if experiment_models is None:
-            return None
-
-        experiment_evaluation = self.parse_experiment_evaluation(
-            experiment_config,
-            experiment_factory.get_factory(KEY_EVALUATION).get_factory(TYPE_RECOMMENDATION)
-        )
-
-        _, experiment_top_k = parse_config_param(
-            experiment_config,
-            'recommender experiment',
-            ConfigValueParam(
-                KEY_TOP_K,
-                int,
-                DEFAULT_TOP_K,
-                (1, 100)
-            ),
-            self.event_dispatcher
-        )
-
-        _, experiment_rated_items_filter = parse_config_param(
-            experiment_config,
-            'recommender experiment',
-            ConfigOptionParam(
-                KEY_RATED_ITEMS_FILTER,
-                bool,
-                DEFAULT_RATED_ITEMS_FILTER,
-                [True, False]
-            ),
-            self.event_dispatcher
-        )
-
-        return RecommenderExperimentConfig(
-            experiment_datasets,
-            experiment_models,
-            experiment_evaluation,
-            experiment_name,
-            experiment_type,
-            experiment_top_k,
-            experiment_rated_items_filter
-        )
-
-    def parse_experiment_name(self, experiment_config):
-        """Parses the name of the experiment.
+    def parse_experiment_name(self, experiment_config: Dict[str, Any]) -> Optional[str]:
+        """Parse the name of the experiment.
 
         Args:
             experiment_config(dict): the experiment's total configuration.
 
         Returns:
-            success(bool): whether the name is available in the configuration.
+            the name of the experiment or None on failure.
         """
         if not assert_is_key_in_dict(
             KEY_NAME,
             experiment_config,
             self.event_dispatcher,
             'PARSE ERROR: missing experiment key \'' + KEY_NAME + '\' (required)'
-        ): return False
+        ): return None
 
         if not assert_is_type(
             experiment_config[KEY_NAME],
             str,
             self.event_dispatcher,
             'PARSE ERROR: invalid value for experiment key \'' + KEY_NAME + '\''
-        ): return False
-
-        return True
-
-    def parse_experiment_datasets(self, experiment_config, data_registry, data_factory):
-        """Parses the datasets of the experiment.
-
-        Args:
-            experiment_config(dict): the experiment's total configuration.
-            data_registry(DataRegistry): the data registry containing the available datasets.
-            data_factory(GroupFactory):
-
-        Returns:
-            experiment_datasets(array like): list of parsed DatasetConfig's or None on failure.
-        """
-        experiment_datasets = parse_data_config(
-            experiment_config,
-            data_registry,
-            data_factory,
-            self.event_dispatcher
-        )
-
-        if not assert_is_container_not_empty(
-            experiment_datasets,
-            self.event_dispatcher,
-            'PARSE ERROR: no experiment ' + KEY_DATASETS + ' specified'
         ): return None
 
-        return experiment_datasets
+        return experiment_config[KEY_NAME]
 
-    def parse_experiment_evaluation(self, experiment_config, metric_factory):
-        """Parses the evaluation of the experiment.
-
-        Args:
-            experiment_config(dict): the experiment's total configuration.
-            metric_factory(MetricFactory): the metric factory containing available metrics.
-
-        Returns:
-            experiment_evaluation(array like): list of parsed MetricConfig's or None on failure.
-        """
-        experiment_evaluation = parse_evaluation_config(
-            experiment_config,
-            metric_factory,
-            self.event_dispatcher
-        )
-
-        return experiment_evaluation
-
-    def parse_experiment_models(self, experiment_config, model_factory):
-        """Parses the models of the experiment.
+    def parse_experiment_top_k(self, recommender_experiment_config: Dict[str, Any]) -> int:
+        """Parse the top K of the recommender experiment.
 
         Args:
-            experiment_config(dict): the experiment's total configuration.
-            model_factory(ModelFactory): the model factory containing the available models.
+            recommender_experiment_config: the experiment's total configuration.
 
         Returns:
-            experiment_models(dict): dictionary of parsed ModelConfig's keyed by API name
-                or None on failure.
-        """
-        experiment_models = parse_models_config(
-            experiment_config,
-            model_factory,
-            self.event_dispatcher
-        )
-
-        if not assert_is_container_not_empty(
-            experiment_models,
-            self.event_dispatcher,
-            'PARSE ERROR: no experiment ' + KEY_MODELS + ' specified'
-        ): return None
-
-        return experiment_models
-
-    def parse_experiment_top_k(self, recommender_experiment_config):
-        """Parses the top K of the recommender experiment.
-
-        Args:
-            recommender_experiment_config(dict): the experiment's total configuration.
-
-        Returns:
-            top_k(int): the topK of the experiment or default_top_k on failure.
+            the topK of the experiment or default_top_k on failure.
         """
         top_k = DEFAULT_TOP_K
 
@@ -306,23 +222,15 @@ class Parser:
 
         return top_k
 
-    def parse_experiment_type(self, experiment_config):
-        """Parses the type of the experiment.
+    def parse_experiment_type(self, experiment_config: Dict[str, Any]) -> Optional[str]:
+        """Parse the type of the experiment.
 
         Args:
-            experiment_config(dict): the experiment's total configuration.
+            experiment_config: the experiment's total configuration.
 
         Returns:
-            experiment_type(str): the type of the experiment or None on failure.
+            the type of the experiment or None on failure.
         """
-        # assert experiment_config is a dict
-        if not assert_is_type(
-            experiment_config,
-            dict,
-            self.event_dispatcher,
-            'PARSE ERROR: invalid experiment config type'
-        ): return None
-
         # assert KEY_TYPE is present
         if not assert_is_key_in_dict(
             KEY_TYPE,

--- a/src/fairreckitlib/experiment/experiment_event.py
+++ b/src/fairreckitlib/experiment/experiment_event.py
@@ -4,17 +4,23 @@ Utrecht University within the Software Project course.
 © Copyright Utrecht University (Department of Information and Computing Sciences)
 """
 
-ON_BEGIN_EXPERIMENT = 'Experiment.on_begin_experiment'
-ON_END_EXPERIMENT = 'Experiment.on_end_experiment'
-ON_BEGIN_THREAD_EXPERIMENT = 'Experiment.on_begin_thread_experiment'
-ON_END_THREAD_EXPERIMENT = 'Experiment.on_end_thread_experiment'
+from typing import Any, Callable, List, Tuple
+
+ON_BEGIN_EXPERIMENT = 'Experiment.on_begin'
+ON_END_EXPERIMENT = 'Experiment.on_end'
+ON_BEGIN_THREAD_EXPERIMENT = 'Experiment.on_begin_thread'
+ON_END_THREAD_EXPERIMENT = 'Experiment.on_end_thread'
 
 
-def get_experiment_events():
-    """Gets all experiment pipeline events.
+def get_experiment_events() -> List[Tuple[str, Callable[[Any], None]]]:
+    """Get all experiment pipeline events.
+
+    The callback functions are specified below and serve as a default
+    implementation for the RecommenderSystem class including the keyword arguments
+    that are passed down by the data pipeline.
 
     Returns:
-        (array like) list of pairs in the format (event_id, func_on_event)
+        a list of pairs in the format (event_id, func_on_event)
     """
     return [
         (ON_BEGIN_EXPERIMENT, on_begin_experiment),
@@ -24,11 +30,11 @@ def get_experiment_events():
     ]
 
 
-def on_begin_experiment(event_listener, **kwargs):
-    """Callback function when a model computation started.
+def on_begin_experiment(event_listener: Any, **kwargs) -> None:
+    """Call back when an experiment started.
 
     Args:
-        event_listener(object): the listener that is registered
+        event_listener: the listener that is registered
             in the event dispatcher with this callback.
 
     Keyword Args:
@@ -38,11 +44,11 @@ def on_begin_experiment(event_listener, **kwargs):
         print('Starting experiment', kwargs['experiment_name'])
 
 
-def on_end_experiment(event_listener, **kwargs):
-    """Callback function when a model computation finished.
+def on_end_experiment(event_listener: Any, **kwargs) -> None:
+    """Call back when an experiment finished.
 
     Args:
-        event_listener(object): the listener that is registered
+        event_listener: the listener that is registered
             in the event dispatcher with this callback.
 
     Keyword Args:
@@ -55,11 +61,11 @@ def on_end_experiment(event_listener, **kwargs):
         print('Finished experiment', kwargs['experiment_name'], f'in {elapsed_time:1.4f}s')
 
 
-def on_begin_thread_experiment(event_listener, **kwargs):
-    """Callback function when a model computation started.
+def on_begin_thread_experiment(event_listener: Any, **kwargs) -> None:
+    """Call back when an experiment thread started.
 
     Args:
-        event_listener(object): the listener that is registered
+        event_listener: the listener that is registered
             in the event dispatcher with this callback.
 
     Keyword Args:
@@ -70,11 +76,11 @@ def on_begin_thread_experiment(event_listener, **kwargs):
         print('Starting', kwargs['num_runs'], 'experiment(s) with name', kwargs['experiment_name'])
 
 
-def on_end_thread_experiment(event_listener, **kwargs):
-    """Callback function when a model computation finished.
+def on_end_thread_experiment(event_listener: Any, **kwargs) -> None:
+    """Call back when an experiment thread finished.
 
     Args:
-        event_listener(object): the listener that is registered
+        event_listener: the listener that is registered
             in the event dispatcher with this callback.
 
     Keyword Args:

--- a/src/fairreckitlib/experiment/experiment_factory.py
+++ b/src/fairreckitlib/experiment/experiment_factory.py
@@ -10,7 +10,17 @@ from ..evaluation.evaluation_factory import create_evaluation_factory
 from ..model.model_factory import create_model_factory
 
 
-def create_experiment_factory():
+def create_experiment_factory() -> GroupFactory:
+    """Create a group factory with all three pipeline factories.
+
+    Consists of three factories:
+        1) data factory.
+        2) model factory.
+        3) evaluation factory.
+
+    Returns:
+        the group factory containing the pipeline factories.
+    """
     experiment_factory = GroupFactory('experiment')
     experiment_factory.add_factory(create_data_factory())
     experiment_factory.add_factory(create_model_factory())

--- a/src/fairreckitlib/experiment/experiment_run.py
+++ b/src/fairreckitlib/experiment/experiment_run.py
@@ -4,81 +4,91 @@ Utrecht University within the Software Project course.
 © Copyright Utrecht University (Department of Information and Computing Sciences)
 """
 
-import time
 import os
+import time
+from typing import Dict, Callable, List, Tuple, Union
 
 import json
 
-from ..core.config_constants import TYPE_RECOMMENDATION
+from ..core.event_dispatcher import EventDispatcher
 from ..core.event_io import ON_MAKE_DIR
-from ..data.pipeline.data_run import run_data_pipeline
+from ..core.factories import GroupFactory
 from ..data.data_factory import KEY_DATASETS
+from ..data.pipeline.data_run import run_data_pipeline
+from ..data.set.dataset_registry import DataRegistry
 from ..evaluation.pipeline.evaluation_run import run_evaluation_pipelines
 from ..evaluation.evaluation_factory import KEY_EVALUATION
 from ..model.pipeline.model_run import run_model_pipelines
 from ..model.model_factory import KEY_MODELS
+from .experiment_config import PredictorExperimentConfig, RecommenderExperimentConfig
 from .experiment_event import ON_BEGIN_EXPERIMENT, ON_END_EXPERIMENT
 
 
 class Experiment:
-    """Experiment wrapper of the data, model and evaluation pipelines.
+    """Experiment wrapper of the data, model and evaluation pipelines."""
 
-    Args:
-        data_registry(DataRegistry):
-        experiment_factory(GroupFactory):
-        config(ExperimentConfig): the configuration of the experiment.
-        event_dispatcher(EventDispatcher): to dispatch the experiment events.
-    """
-    def __init__(self, data_registry, experiment_factory, config, event_dispatcher):
-        self.data_registry = data_registry
-        self.experiment_factory = experiment_factory
-        self.config = config
-
-        self.event_dispatcher = event_dispatcher
-
-    def get_config(self):
-        """Gets the configuration of the experiment.
-
-        Returns:
-            (ExperimentConfig): the used configuration.
-        """
-        return self.config
-
-    def run(self, output_dir, num_threads, is_running):
-        """Runs an experiment with the specified configuration.
+    def __init__(
+            self,
+            data_registry: DataRegistry,
+            experiment_factory: GroupFactory,
+            experiment_config: Union[PredictorExperimentConfig, RecommenderExperimentConfig],
+            event_dispatcher: EventDispatcher):
+        """Construct the experiment.
 
         Args:
-            output_dir(str): the path of the directory to store the output.
-            num_threads(int): the max number of threads the experiment can use.
-            is_running(func -> bool): function that returns whether the experiment
+            data_registry(DataRegistry): the registry with available datasets.
+            experiment_factory(GroupFactory): the factory containing all three pipeline factories.
+            experiment_config: the configuration of the experiment.
+            event_dispatcher: to dispatch the experiment events.
+        """
+        self.data_registry = data_registry
+        self.experiment_factory = experiment_factory
+        self.experiment_config = experiment_config
+        self.event_dispatcher = event_dispatcher
+
+    def get_config(self) -> Union[PredictorExperimentConfig, RecommenderExperimentConfig]:
+        """Get the configuration of the experiment.
+
+        Returns:
+            the used configuration.
+        """
+        return self.experiment_config
+
+    def run(self, output_dir: str, num_threads: int, is_running: Callable[[], bool]) -> None:
+        """Run the experiment with the specified configuration.
+
+        Args:
+            output_dir: the path of the directory to store the output.
+            num_threads: the max number of threads the experiment can use.
+            is_running: function that returns whether the experiment
                 is still running. Stops early when False is returned.
         """
-
         results, start_time = self.start_run(output_dir)
 
         data_result = run_data_pipeline(
             output_dir,
             self.data_registry,
             self.experiment_factory.get_factory(KEY_DATASETS),
-            self.config.datasets,
+            self.experiment_config.datasets,
             self.event_dispatcher,
             is_running
         )
 
         kwargs = {'num_threads': num_threads}
-        if self.config.type == TYPE_RECOMMENDATION:
-            kwargs['num_items'] = self.config.top_k
-            kwargs['rated_items_filter'] = self.config.rated_items_filter
+        if isinstance(self.experiment_config, RecommenderExperimentConfig):
+            kwargs['num_items'] = self.experiment_config.top_k
+            kwargs['rated_items_filter'] = self.experiment_config.rated_items_filter
 
         for data_transition in data_result:
             if not is_running():
                 return
 
+            model_factory = self.experiment_factory.get_factory(KEY_MODELS)
             model_dirs = run_model_pipelines(
                 data_transition.output_dir,
                 data_transition,
-                self.experiment_factory.get_factory(KEY_MODELS).get_factory(self.config.type),
-                self.config.models,
+                model_factory.get_factory(self.experiment_config.type),
+                self.experiment_config.models,
                 self.event_dispatcher,
                 is_running,
                 **kwargs
@@ -86,12 +96,13 @@ class Experiment:
             if not is_running():
                 return
 
-            if len(self.config.evaluation) > 0:
+            if len(self.experiment_config.evaluation) > 0:
+                evaluation_factory = self.experiment_factory.get_factory(KEY_EVALUATION)
                 run_evaluation_pipelines(
                     model_dirs,
                     data_transition,
-                    self.experiment_factory.get_factory(KEY_EVALUATION).get_factory(self.config.type),
-                    self.config.evaluation,
+                    evaluation_factory.get_factory(self.experiment_config.type),
+                    self.experiment_config.evaluation,
                     self.event_dispatcher,
                     is_running,
                     **kwargs
@@ -101,20 +112,19 @@ class Experiment:
 
         self.end_run(start_time, output_dir, results)
 
-    def start_run(self, output_dir):
-        """Start the run, making the output dir and initialising the results storage list.
+    def start_run(self, output_dir: str) -> Tuple[List[Dict[str, str]], float]:
+        """Start the run, making the output dir and initialising the results' storage list.
 
         Args:
-            output_dir(str): directory in which to store the run storage output
+            output_dir: directory in which to store the run storage output.
 
         Returns:
-            results(list): the initial results list
-            start_time(float): the time the experiment started
+            the initial results list and the time the experiment started.
         """
         start_time = time.time()
         self.event_dispatcher.dispatch(
             ON_BEGIN_EXPERIMENT,
-            experiment_name=self.config.name
+            experiment_name=self.experiment_config.name
         )
 
         os.mkdir(output_dir)
@@ -125,28 +135,27 @@ class Experiment:
 
         return [], start_time
 
-    def end_run(self, start_time, output_dir, results):
+    def end_run(self, start_time: float, output_dir: str, results: List[Dict[str, str]]) -> None:
         """End the run, writing the storage file and storing the results.
 
         Args:
-            start_time(float): time the experiment started
-            output_dir(str): directory in which to store the run storage output
-            results(list): the results list
-
-        Returns:
+            start_time: time the experiment started.
+            output_dir: directory in which to store the run storage output.
+            results: the current results list.
         """
         write_storage_file(output_dir, results)
 
         self.event_dispatcher.dispatch(
             ON_END_EXPERIMENT,
-            experiment_name=self.config.name,
+            experiment_name=self.experiment_config.name,
             elapsed_time=time.time()-start_time
         )
 
 
-def add_result_to_overview(results, model_dirs):
-    """Add result to overview of results file paths"""
-
+def add_result_to_overview(
+        results: List[Dict[str, str]],
+        model_dirs: List[str]) -> List[Dict[str, str]]:
+    """Add result to overview of results file paths."""
     for model_dir in model_dirs:
         # Our evaluations are in the same directory as the model ratings
         result = {
@@ -159,9 +168,8 @@ def add_result_to_overview(results, model_dirs):
     return results
 
 
-def write_storage_file(output_dir, results):
-    """Write a JSON file with overview of the results file paths"""
-
+def write_storage_file(output_dir: str, results: List[Dict[str, str]]) -> None:
+    """Write a JSON file with overview of the results file paths."""
     formatted_results = map(lambda result: {
         'name': result['dataset'] + '_' + result['model'],
         'evaluation_path': result['dir'] + '\\evaluations.json',
@@ -173,14 +181,14 @@ def write_storage_file(output_dir, results):
         json.dump({'overview': list(formatted_results)}, file, indent=4)
 
 
-def resolve_experiment_start_run(result_dir):
-    """Resolves which run will be next in the specified result directory.
+def resolve_experiment_start_run(result_dir: str) -> int:
+    """Resolve which run will be next in the specified result directory.
 
     Args:
-        result_dir(str): path to the result directory to look into.
+        result_dir: path to the result directory to look into.
 
     Returns:
-        start_run(int): the next run index for this result directory.
+        the next run index for this result directory.
     """
     start_run = 0
 

--- a/src/fairreckitlib/model/algorithms/top_k_recommender.py
+++ b/src/fairreckitlib/model/algorithms/top_k_recommender.py
@@ -83,6 +83,7 @@ class TopK(BaseRecommender):
         Returns:
             dataframe with the columns: 'item' and 'score'.
         """
+        items = self.items
         # filter items that are rated by the user already
         if self.rated_items_filter:
             is_user = self.train_set['user'] == user
@@ -91,7 +92,7 @@ class TopK(BaseRecommender):
 
         # TODO this is not very efficient, but works (also should utilize available num_threads)
         # compute recommendations for all items and truncate to the top num_items
-        item_ratings = list(map(lambda i: (i, self.predictor.predict(user, i)), self.items))
+        item_ratings = list(map(lambda i: (i, self.predictor.predict(user, i)), items))
         item_ratings.sort(key=lambda i: i[1], reverse=True)
 
         return pd.DataFrame(item_ratings[:num_items], columns=['item', 'score'])

--- a/src/fairreckitlib/model/pipeline/model_config.py
+++ b/src/fairreckitlib/model/pipeline/model_config.py
@@ -5,14 +5,28 @@ Utrecht University within the Software Project course.
 """
 
 from dataclasses import dataclass
-from typing import Any, Dict
+from typing import Any, Dict, List
+
+from ...core.config_object import ObjectConfig, object_config_list_to_yml_format
 
 KEY_MODELS = 'models'
 
 
 @dataclass
-class ModelConfig:
+class ModelConfig(ObjectConfig):
     """Model Configuration."""
 
-    name: str
-    params: Dict[str, Any]
+
+def api_models_to_yml_format(
+        api_models: Dict[str, List[ModelConfig]]) -> Dict[str, List[Dict[str, Any]]]:
+    """Format API models configuration list to a yml compatible dictionary.
+
+    Returns:
+        a dictionary containing the lists of model configurations.
+    """
+    yml_format = {}
+
+    for api_name, models in api_models.items():
+        yml_format[api_name] = object_config_list_to_yml_format(models)
+
+    return yml_format

--- a/src/fairreckitlib/model/pipeline/model_config_parsing.py
+++ b/src/fairreckitlib/model/pipeline/model_config_parsing.py
@@ -4,7 +4,7 @@ Utrecht University within the Software Project course.
 © Copyright Utrecht University (Department of Information and Computing Sciences)
 """
 
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 from ...core.config_constants import KEY_NAME, KEY_PARAMS
 from ...core.event_dispatcher import EventDispatcher
@@ -20,7 +20,7 @@ from .model_config import ModelConfig
 def parse_models_config(
         experiment_config: Dict[str, Any],
         model_factory: GroupFactory,
-        event_dispatcher: EventDispatcher) -> Dict[str, List[ModelConfig]]:
+        event_dispatcher: EventDispatcher) -> Optional[Dict[str, List[ModelConfig]]]:
     """Parse all model configurations.
 
     Args:
@@ -29,7 +29,7 @@ def parse_models_config(
         event_dispatcher: to dispatch the parse event on failure.
 
     Returns:
-        a dictionary of parsed ModelConfig's keyed by API name.
+        a dictionary of parsed ModelConfig's keyed by API name or None when empty.
     """
     parsed_config = {}
 
@@ -79,6 +79,12 @@ def parse_models_config(
         ): continue
 
         parsed_config[api_name] = api_config
+
+    if not assert_is_container_not_empty(
+        parsed_config,
+        event_dispatcher,
+        'PARSE ERROR: no experiment ' + KEY_MODELS + ' specified'
+    ): return None
 
     return parsed_config
 

--- a/src/fairreckitlib/recommender_system.py
+++ b/src/fairreckitlib/recommender_system.py
@@ -18,7 +18,6 @@ from .evaluation.evaluation_factory import KEY_EVALUATION
 from .evaluation.pipeline.evaluation_event import get_evaluation_events
 from .experiment.experiment_event import get_experiment_events
 from .experiment.experiment_config import ExperimentConfig
-from .experiment.experiment_config import experiment_config_to_dict
 from .experiment.experiment_config_parsing import Parser
 from .experiment.experiment_factory import create_experiment_factory
 from .experiment.experiment_run import resolve_experiment_start_run
@@ -69,7 +68,7 @@ class RecommenderSystem:
 
         if validate_config:
             parser = Parser(verbose)
-            config = parser.parse_experiment_config(experiment_config_to_dict(config),
+            config = parser.parse_experiment_config(config.to_yml_format(),
                                                     self.data_registry,
                                                     self.experiment_factory)
             if config is None:


### PR DESCRIPTION
- Added base ConfigObject dataclass for name/param objects (filter/splitter/converter/model/metric)
- Added to_yml_format functions to convert experiment Config's to a yml compatible format as counterpart to the parsing functionality.
- Simplified prediction/recommender experiment parsing.
- Added rating converter parsing.
- Updated experiment module, together with docstrings and type annotations.
- Fixed minor refactoring error in top k recommender.